### PR TITLE
Add webhook validation for zone and resource group when infra is created

### DIFF
--- a/api/v1beta2/ibmpowervscluster_webhook.go
+++ b/api/v1beta2/ibmpowervscluster_webhook.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v1beta2
 
 import (
+	"strconv"
+
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -74,6 +76,11 @@ func (r *IBMPowerVSCluster) validateIBMPowerVSCluster() (admission.Warnings, err
 	if err := r.validateIBMPowerVSClusterNetwork(); err != nil {
 		allErrs = append(allErrs, err)
 	}
+
+	if err := r.validateIBMPowerVSClusterCreateInfraPrereq(); err != nil {
+		allErrs = append(allErrs, err)
+	}
+
 	if len(allErrs) == 0 {
 		return nil, nil
 	}
@@ -87,5 +94,36 @@ func (r *IBMPowerVSCluster) validateIBMPowerVSClusterNetwork() *field.Error {
 	if res, err := validateIBMPowerVSNetworkReference(r.Spec.Network); !res {
 		return err
 	}
+	return nil
+}
+
+func (r *IBMPowerVSCluster) validateIBMPowerVSClusterCreateInfraPrereq() *field.Error {
+	annotations := r.GetAnnotations()
+	if len(annotations) == 0 {
+		return nil
+	}
+
+	value, found := annotations[CreateInfrastructureAnnotation]
+	if !found {
+		return nil
+	}
+
+	createInfra, err := strconv.ParseBool(value)
+	if err != nil {
+		return field.Invalid(field.NewPath("annotations"), r.Annotations, "value of powervs.cluster.x-k8s.io/create-infra should be boolean")
+	}
+
+	if !createInfra {
+		return nil
+	}
+
+	if r.Spec.Zone == nil {
+		return field.Invalid(field.NewPath("spec.zone"), r.Spec.Zone, "value of zone is empty")
+	}
+
+	if r.Spec.ResourceGroup == nil {
+		return field.Invalid(field.NewPath("spec.resourceGroup"), r.Spec.ResourceGroup, "value of resource group is empty")
+	}
+
 	return nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/area provider/ibmcloud

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
